### PR TITLE
Seasalt ed25519 and hasher migration

### DIFF
--- a/lang/jvm/src/main/scala/com/ltonetwork/lang/Global.scala
+++ b/lang/jvm/src/main/scala/com/ltonetwork/lang/Global.scala
@@ -3,7 +3,7 @@ package com.ltonetwork.lang
 import com.emstlk.nacl4s.VerifyKey
 import com.ltonetwork.lang.v1.BaseGlobal
 import com.ltonetwork.utils.{Base58, Base64}
-import scorex.crypto.hash.{Blake2b256, Keccak256, Sha256}
+import com.ltonetwork.seasalt.hash.{Blake2b256, Keccak256, SHA256}
 
 import scala.util.Try
 
@@ -28,7 +28,7 @@ object Global extends BaseGlobal {
   def signatureVerify(message: Array[Byte], sig: Array[Byte], pub: Array[Byte]): Boolean =
     Try(VerifyKey(pub).verify(message, sig)).fold(_ => false, _ => true)
 
-  def keccak256(message: Array[Byte]): Array[Byte]  = Keccak256.hash(message)
-  def blake2b256(message: Array[Byte]): Array[Byte] = Blake2b256.hash(message)
-  def sha256(message: Array[Byte]): Array[Byte]     = Sha256.hash(message)
+  def keccak256(message: Array[Byte]): Array[Byte]  = Keccak256.hash(message).getBytes
+  def blake2b256(message: Array[Byte]): Array[Byte] = Blake2b256.hash(message).getBytes
+  def sha256(message: Array[Byte]): Array[Byte]     = SHA256.hash(message).getBytes
 }

--- a/lang/jvm/src/test/scala/com/ltonetwork/lang/EvaluatorV1Test.scala
+++ b/lang/jvm/src/test/scala/com/ltonetwork/lang/EvaluatorV1Test.scala
@@ -1,7 +1,6 @@
 package com.ltonetwork.lang
 
 import java.nio.ByteBuffer
-
 import cats.data.EitherT
 import cats.kernel.Monoid
 import com.ltonetwork.lang.Common._
@@ -9,7 +8,7 @@ import com.ltonetwork.lang.ExprEvaluator.Log
 import com.ltonetwork.lang.v1.compiler.CompilerV1
 import com.ltonetwork.lang.v1.compiler.Terms._
 import com.ltonetwork.lang.v1.compiler.Types._
-import com.ltonetwork.lang.v1.evaluator.EvaluatorV1
+import com.ltonetwork.lang.v1.evaluator.{EvaluatorV1, FunctionIds}
 import com.ltonetwork.lang.v1.evaluator.FunctionIds._
 import com.ltonetwork.lang.v1.evaluator.ctx._
 import com.ltonetwork.lang.v1.evaluator.ctx.impl.PureContext._
@@ -18,8 +17,8 @@ import com.ltonetwork.lang.v1.evaluator.ctx.impl.{CryptoContext, EnvironmentFunc
 import com.ltonetwork.lang.v1.testing.ScriptGen
 import com.ltonetwork.lang.v1.traits.Environment
 import com.ltonetwork.lang.v1.{CTX, FunctionHeader}
+import com.ltonetwork.seasalt.hash.{Blake2b256, Keccak256, SHA256}
 import com.ltonetwork.utils.{Base58, Base64}
-import com.ltonetwork.seasalt.hash.Hasher
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
@@ -698,9 +697,10 @@ class EvaluatorV1Test extends PropSpec with PropertyChecks with Matchers with Sc
   property("checking a hash of some message by crypto function invoking") {
     val bodyText      = "some text for test"
     val bodyBytes     = bodyText.getBytes()
-    val hashFunctions = Map(SHA256 -> new Hasher("SHA-256"), BLAKE256 -> new Hasher("Blake2b-256"), KECCAK256 -> new Hasher("Keccak-256"))
 
-    for ((funcName, funcClass) <- hashFunctions) hashFuncTest(bodyBytes, funcName) shouldBe Right(ByteVector(funcClass.hash(bodyText).getBytes))
+    hashFuncTest(bodyBytes, FunctionIds.SHA256) shouldBe Right(ByteVector(SHA256.hash(bodyText).getBytes))
+    hashFuncTest(bodyBytes, FunctionIds.BLAKE256) shouldBe Right(ByteVector(Blake2b256.hash(bodyText).getBytes))
+    hashFuncTest(bodyBytes, FunctionIds.KECCAK256) shouldBe Right(ByteVector(Keccak256.hash(bodyText).getBytes))
   }
 
   private def hashFuncTest(bodyBytes: Array[Byte], funcName: Short): Either[ExecutionError, ByteVector] = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -103,7 +103,7 @@ object Dependencies {
     "io.github.amrhassan" %% "scalacheck-cats" % "0.4.0" % Test
   )
   lazy val kindProjector = "org.spire-math" %% "kind-projector" % "0.9.6"
-  lazy val seasalt = Seq("com.ltonetwork" % "seasalt" % "0.0.4")
+  lazy val seasalt = Seq("com.ltonetwork" % "seasalt" % "0.0.5")
   lazy val jaxb_api = Seq(
     "javax.xml.bind" % "jaxb-api" % "2.3.0",
     "com.sun.xml.bind" % "jaxb-core" % "2.3.0",

--- a/src/main/scala/com/ltonetwork/GenesisBlockGenerator.scala
+++ b/src/main/scala/com/ltonetwork/GenesisBlockGenerator.scala
@@ -5,7 +5,7 @@ import com.ltonetwork.block.Block
 import com.ltonetwork.consensus.PoSCalculator.{generatorSignature, hit}
 import com.ltonetwork.consensus.nxt.NxtLikeConsensusBlockData
 import com.ltonetwork.consensus.{FairPoSCalculator, PoSCalculator}
-import com.ltonetwork.crypto.SignatureLength
+import com.ltonetwork.crypto.signatureLength
 import com.ltonetwork.features.{BlockchainFeature, BlockchainFeatures}
 import com.ltonetwork.settings.{FunctionalitySettings, GenesisSettings, GenesisTransactionSettings}
 import com.ltonetwork.state._
@@ -178,7 +178,7 @@ object GenesisBlockGenerator extends App {
       .getOrElse(mkGenesisSettings(calcInitialBaseTarget()))
 
   def mkGenesisSettings(baseTarget: Long): GenesisSettings = {
-    val reference     = ByteStr(Array.fill(SignatureLength)(-1: Byte))
+    val reference     = ByteStr(Array.fill(signatureLength)(-1: Byte))
     val genesisSigner = PrivateKeyAccount(ByteStr.empty)
 
     val genesis = Block
@@ -186,7 +186,7 @@ object GenesisBlockGenerator extends App {
         version = 1,
         timestamp = timestamp,
         reference = reference,
-        consensusData = NxtLikeConsensusBlockData(baseTarget, ByteStr(Array.fill(crypto.DigestLength)(0: Byte))),
+        consensusData = NxtLikeConsensusBlockData(baseTarget, ByteStr(Array.fill(crypto.digestLength)(0: Byte))),
         transactionData = genesisTxs,
         signer = genesisSigner,
         featureVotes = Set.empty
@@ -209,7 +209,7 @@ object GenesisBlockGenerator extends App {
   def calcInitialBaseTarget(): Long = {
     val posCalculator: PoSCalculator = FairPoSCalculator
 
-    val hitSource = ByteStr(new Array[Byte](crypto.DigestLength))
+    val hitSource = ByteStr(new Array[Byte](crypto.digestLength))
 
     def getHit(account: PrivateKeyAccount): BigInt = {
       val gs = generatorSignature(hitSource, account.publicKey)

--- a/src/main/scala/com/ltonetwork/api/http/requests/package.scala
+++ b/src/main/scala/com/ltonetwork/api/http/requests/package.scala
@@ -3,7 +3,7 @@ package com.ltonetwork.api.http
 import cats.Applicative
 import com.ltonetwork.account.KeyType
 import com.ltonetwork.account.KeyTypes.{ED25519, SECP256K1, SECP256R1}
-import com.ltonetwork.crypto.{DigestLength, SignatureLength}
+import com.ltonetwork.crypto.{digestLength, signatureLength}
 import com.ltonetwork.state.ByteStr
 import com.ltonetwork.transaction.ValidationError._
 import com.ltonetwork.transaction.{Proofs, TransactionBuilder, ValidationError}
@@ -16,8 +16,8 @@ package object requests {
   import cats.syntax.either._
   import cats.syntax.traverse._
 
-  val SignatureStringLength: Int = base58Length(SignatureLength)
-  val DigestStringLength: Int    = base58Length(DigestLength)
+  val SignatureStringLength: Int = base58Length(signatureLength)
+  val DigestStringLength: Int    = base58Length(digestLength)
 
   def parseBase58(v: String, error: String, maxLength: Int): Validation[ByteStr] =
     if (v.length > maxLength) Left(GenericError(error))

--- a/src/main/scala/com/ltonetwork/block/Block.scala
+++ b/src/main/scala/com/ltonetwork/block/Block.scala
@@ -274,7 +274,7 @@ object Block extends ScorexLogging {
 
     val transactionGenesisData      = genesisTransactions(genesisSettings)
     val transactionGenesisDataField = TransactionsBlockField.Version1or2(transactionGenesisData)
-    val consensusGenesisData        = NxtLikeConsensusBlockData(genesisSettings.initialBaseTarget, ByteStr(Array.fill(crypto.DigestLength)(0: Byte)))
+    val consensusGenesisData        = NxtLikeConsensusBlockData(genesisSettings.initialBaseTarget, ByteStr(Array.fill(crypto.digestLength)(0: Byte)))
     val consensusGenesisDataField   = NxtConsensusBlockField(consensusGenesisData)
     val txBytesSize                 = transactionGenesisDataField.bytes().length
     val txBytes                     = Bytes.ensureCapacity(Ints.toByteArray(txBytesSize), 4, 0) ++ transactionGenesisDataField.bytes()

--- a/src/main/scala/com/ltonetwork/consensus/PoSCalculator.scala
+++ b/src/main/scala/com/ltonetwork/consensus/PoSCalculator.scala
@@ -18,9 +18,9 @@ object PoSCalculator {
   val MinBaseTarget: Long             = 9
 
   def generatorSignature(signature: Array[Byte], publicKey: Array[Byte]): Array[Byte] = {
-    val s = new Array[Byte](crypto.DigestLength * 2)
-    System.arraycopy(signature, 0, s, 0, crypto.DigestLength)
-    System.arraycopy(publicKey, 0, s, crypto.DigestLength, crypto.DigestLength)
+    val s = new Array[Byte](crypto.digestLength * 2)
+    System.arraycopy(signature, 0, s, 0, crypto.digestLength)
+    System.arraycopy(publicKey, 0, s, crypto.digestLength, crypto.digestLength)
     crypto.fastHash(s)
   }
 

--- a/src/main/scala/com/ltonetwork/crypto/package.scala
+++ b/src/main/scala/com/ltonetwork/crypto/package.scala
@@ -1,23 +1,20 @@
 package com.ltonetwork
 
-import com.emstlk.nacl4s.crypto.SigningKeyPair
-import com.emstlk.nacl4s.{SigningKey, VerifyKey}
 import com.ltonetwork.account.{KeyType, KeyTypes, PrivateKeyAccount, PublicKeyAccount}
 import com.ltonetwork.seasalt.sign.{ECDSA, Ed25519}
-import scorex.crypto.hash.{Blake2b256, Sha256}
-
-import scala.util.Try
+import com.ltonetwork.seasalt.hash.{Blake2b256, SHA256}
 
 package object crypto {
   val signatureLength: Int = 64 //Curve25519
   val keyLength: Int       = 32 //Curve25519
   val digestLength: Int    = 32
-  val secp256k1: ECDSA = new ECDSA("secp256k1");
-  val secp256r1: ECDSA = new ECDSA("secp256r1");
+  val secp256k1: ECDSA = new ECDSA("secp256k1")
+  val secp256r1: ECDSA = new ECDSA("secp256r1")
+  val ed25519: Ed25519 = new Ed25519()
 
-  def fastHash(m: Array[Byte]): Array[Byte]   = Blake2b256.hash(m)
+  def fastHash(m: Array[Byte]): Array[Byte]   = Blake2b256.hash(m).getBytes
   def fastHash(s: String): Array[Byte]        = fastHash(s.getBytes())
-  def secureHash(m: Array[Byte]): Array[Byte] = Sha256.hash(Blake2b256.hash(m))
+  def secureHash(m: Array[Byte]): Array[Byte] = SHA256.hash(Blake2b256.hash(m)).getBytes
   def secureHash(s: String): Array[Byte]      = secureHash(s.getBytes())
 
   def sign(account: PrivateKeyAccount, message: Array[Byte]): Array[Byte] =
@@ -28,7 +25,7 @@ package object crypto {
 
   def sign(privateKey: Array[Byte], keyType: KeyType, message: Array[Byte]): Array[Byte] = keyType match {
     case KeyTypes.ED25519 =>
-      SigningKey(privateKey).sign(message)
+      ed25519.signDetached(message, privateKey).getBytes
     case KeyTypes.SECP256K1 =>
       secp256k1.signDetached(message, privateKey).getBytes
     case KeyTypes.SECP256R1 =>
@@ -45,7 +42,7 @@ package object crypto {
 
   def verify(signature: Array[Byte], message: Array[Byte], publicKey: Array[Byte], keyType: KeyType): Boolean = keyType match {
     case KeyTypes.ED25519 =>
-      Try(VerifyKey(publicKey).verify(message, signature)).fold(_ => false, _ => true)
+      ed25519.verify(message, signature, publicKey)
     case KeyTypes.SECP256K1 =>
       secp256k1.verify(message, signature, publicKey)
     case KeyTypes.SECP256R1 =>
@@ -59,10 +56,8 @@ package object crypto {
 
   def createKeyPair(seed: Array[Byte], keyType: KeyType): (Array[Byte], Array[Byte]) = keyType match {
     case KeyTypes.ED25519 =>
-      //val hash = new Hasher("SHA-256").hash(seed).getBytes
-      //val kp   = SigningKeyPair(hash)
-      val kp = SigningKeyPair(Sha256.hash(seed))
-      (kp.privateKey, kp.publicKey)
+      val kp = ed25519.keyPairFromSeed(seed)
+      (kp.getPrivateKey.getBytes, kp.getPublicKey.getBytes)
     case KeyTypes.SECP256K1 =>
       val kp = secp256k1.keyPairFromSeed(seed)
       (kp.getPrivateKey.getBytes, kp.getPublicKey.getBytes)

--- a/src/main/scala/com/ltonetwork/database/package.scala
+++ b/src/main/scala/com/ltonetwork/database/package.scala
@@ -62,8 +62,8 @@ package object database {
 
     while (b.remaining() > 0) {
       val buffer = b.get() match {
-        case crypto.DigestLength    => new Array[Byte](crypto.DigestLength)
-        case crypto.SignatureLength => new Array[Byte](crypto.SignatureLength)
+        case crypto.`digestLength`    => new Array[Byte](crypto.digestLength)
+        case crypto.`signatureLength` => new Array[Byte](crypto.signatureLength)
       }
       b.get(buffer)
       ids += ByteStr(buffer)
@@ -77,8 +77,8 @@ package object database {
       .foldLeft(ByteBuffer.allocate(ids.map(_.arr.length + 1).sum)) {
         case (b, id) =>
           b.put(id.arr.length match {
-              case crypto.DigestLength    => crypto.DigestLength.toByte
-              case crypto.SignatureLength => crypto.SignatureLength.toByte
+              case crypto.`digestLength`    => crypto.digestLength.toByte
+              case crypto.`signatureLength` => crypto.signatureLength.toByte
             })
             .put(id.arr)
       }

--- a/src/main/scala/com/ltonetwork/transaction/lease/CancelLeaseTransaction.scala
+++ b/src/main/scala/com/ltonetwork/transaction/lease/CancelLeaseTransaction.scala
@@ -58,7 +58,7 @@ object CancelLeaseTransaction extends TransactionBuilder.For[CancelLeaseTransact
       seq(tx)(
         Validated.condNel(supportedVersions.contains(version), (), ValidationError.UnsupportedVersion(version)),
         Validated.condNel(chainId == networkByte, (), ValidationError.WrongChainId(chainId)),
-        Validated.condNel(leaseId.arr.length == crypto.DigestLength, (), ValidationError.GenericError("Lease transaction id is invalid")),
+        Validated.condNel(leaseId.arr.length == crypto.digestLength, (), ValidationError.GenericError("Lease transaction id is invalid")),
         Validated.condNel(fee > 0, (), ValidationError.InsufficientFee()),
         Validated.condNel(sponsor.isEmpty || version >= 3,
                           (),

--- a/src/test/scala/com/ltonetwork/state/RollbackSpec.scala
+++ b/src/test/scala/com/ltonetwork/state/RollbackSpec.scala
@@ -1,7 +1,7 @@
 package com.ltonetwork.state
 
 import com.ltonetwork.account.{Address, PrivateKeyAccount}
-import com.ltonetwork.crypto.SignatureLength
+import com.ltonetwork.crypto.signatureLength
 import com.ltonetwork.db.WithState
 import com.ltonetwork.features._
 import com.ltonetwork.lagonaki.mocks.TestBlock
@@ -26,11 +26,11 @@ class RollbackSpec extends FreeSpec with Matchers with WithState with Transactio
 
   private def genesisBlock(genesisTs: Long, address: Address, initialBalance: Long) = TestBlock.create(
     genesisTs,
-    ByteStr(Array.fill[Byte](SignatureLength)(0)),
+    ByteStr(Array.fill[Byte](signatureLength)(0)),
     Seq(GenesisTransaction.create(address, initialBalance, genesisTs).explicitGet())
   )
   private def genesisBlock(genesisTs: Long, balances: Seq[(Address, Long)]) =
-    TestBlock.create(genesisTs, ByteStr(Array.fill[Byte](SignatureLength)(0)), balances.map {
+    TestBlock.create(genesisTs, ByteStr(Array.fill[Byte](signatureLength)(0)), balances.map {
       case (addr, amt) => GenesisTransaction.create(addr, amt, genesisTs).explicitGet()
     })
 

--- a/src/test/scala/tools/GenesisBlockGenerator.scala
+++ b/src/test/scala/tools/GenesisBlockGenerator.scala
@@ -85,7 +85,7 @@ object GenesisBlockGenerator extends App {
   }.toSeq
 
   val genesisBlock: Block = {
-    val reference     = ByteStr(Array.fill(crypto.SignatureLength)(-1: Byte))
+    val reference     = ByteStr(Array.fill(crypto.signatureLength)(-1: Byte))
     val genesisSigner = PrivateKeyAccount(Array.empty)
 
     Block
@@ -93,7 +93,7 @@ object GenesisBlockGenerator extends App {
         version = 1,
         timestamp = timestamp,
         reference = reference,
-        consensusData = NxtLikeConsensusBlockData(settings.baseTarget, ByteStr(Array.fill(crypto.DigestLength)(0: Byte))),
+        consensusData = NxtLikeConsensusBlockData(settings.baseTarget, ByteStr(Array.fill(crypto.digestLength)(0: Byte))),
         transactionData = genesisTxs,
         signer = genesisSigner,
         featureVotes = Set.empty


### PR DESCRIPTION
- Bump Seasalt version to 0.0.5
- Migrate to ed25519 signing, verifying and key creation in `crypto/package.scala`
- Refactor ECDSA signing and verifying for efficiency (create the object in the class, not in the function) in `crypto/package.scala`
- Change scorex (or previous implementation of Seasalt) hashing functions to Seasalt in `crypto/package.scala` and in `lang/jvm/...`
- change PascalCase variable to camelCase