### PR TITLE
Prioritize revoked associations

### DIFF
--- a/e2e/features/association.feature
+++ b/e2e/features/association.feature
@@ -21,11 +21,9 @@ Feature: Association
     When Alice tries to issue an association with Bob of type 1
     Then The transaction fails
 
-  # Wait after association because of https://github.com/ltonetwork/lto-public-chain/issues/106
   Scenario Outline: Successful revoke association
     Given Alice has an association with Bob of type 1
     And Alice has 10 lto
-    And wait
     When Alice revokes the association (<version>) with Bob of type 1
     Then Alice is not associated with Bob
     And Alice has 9 lto
@@ -49,11 +47,9 @@ Feature: Association
     Then Alice has 8 lto
     And Alice is not associated with Bob
     
-  # Wait after association because of https://github.com/ltonetwork/lto-public-chain/issues/106
   Scenario: Revoke association with anchor
     Given Alice has an association with Bob of type 76 and anchor qwerty
     And Alice has 10 lto
-    And wait
     When Alice revokes the association with Bob of type 76 and anchor qwerty
     Then Alice has 9 lto
     And Alice is not associated with Bob

--- a/e2e/features/association.feature
+++ b/e2e/features/association.feature
@@ -41,13 +41,11 @@ Feature: Association
     When Alice tries to revoke an association with Bob of type 1
     Then The transaction fails
 
-  @skip
-  # https://github.com/ltonetwork/lto-public-chain/issues/103
   Scenario: Reissue a revoked association
     Given Alice has an association with Bob of type 5
     And Alice has 10 lto
     When Alice revokes the association with Bob of type 5
-    And Alice tries to issues an association with Bob of type 5
+    And Alice tries to issue an association with Bob of type 5
     Then Alice has 8 lto
     And Alice is not associated with Bob
     

--- a/src/main/scala/com/ltonetwork/api/http/AssociationsApiRoute.scala
+++ b/src/main/scala/com/ltonetwork/api/http/AssociationsApiRoute.scala
@@ -65,9 +65,9 @@ case class AssociationsApiRoute(settings: RestAPISettings,
   }
 
   private def associationsJson(address: Address, associations: Blockchain.Associations): AssociationsInfo = {
-    def fold(list: List[(Int, AssociationTransaction)]) = {
+    def fold(list: List[(Int, AssociationTransaction)]): List[AssociationInfo] = {
       list
-        .sortBy(_._2.typeId)
+        .sortBy(t => (t._2.timestamp, t._2.typeId))
         .foldLeft(Map.empty[(Int, Address, Option[ByteStr]), (Int, Address, ByteStr, Option[(Int, ByteStr)])]) {
           case (acc, (height, tx: AssociationTransaction)) =>
             val cp = if (address == tx.sender.toAddress) tx.recipient else tx.sender.toAddress

--- a/src/main/scala/com/ltonetwork/api/http/AssociationsApiRoute.scala
+++ b/src/main/scala/com/ltonetwork/api/http/AssociationsApiRoute.scala
@@ -67,6 +67,7 @@ case class AssociationsApiRoute(settings: RestAPISettings,
   private def associationsJson(address: Address, associations: Blockchain.Associations): AssociationsInfo = {
     def fold(list: List[(Int, AssociationTransaction)]) = {
       list
+        .sortBy(_._2.typeId)
         .foldLeft(Map.empty[(Int, Address, Option[ByteStr]), (Int, Address, ByteStr, Option[(Int, ByteStr)])]) {
           case (acc, (height, tx: AssociationTransaction)) =>
             val cp = if (address == tx.sender.toAddress) tx.recipient else tx.sender.toAddress

--- a/src/main/scala/com/ltonetwork/state/package.scala
+++ b/src/main/scala/com/ltonetwork/state/package.scala
@@ -47,8 +47,11 @@ package object state {
   }
 
   implicit class BlockchainExt(blockchain: Blockchain) extends ScorexLogging {
-    def assocExists(tx: AssociationTransaction): Boolean =
-      blockchain.associations(tx.sender).outgoing.map(_._2).exists(as => tx.assoc == as.assoc)
+    def assocExists(tx: AssociationTransaction): Boolean = {
+      blockchain.associations(tx.sender).outgoing.map(_._2).exists(as => tx.assoc == as.assoc) &&
+      // https://github.com/ltonetwork/lto-public-chain/issues/111
+      blockchain.associations(tx.sender).outgoing.map(_._2).maxBy(_.timestamp).typeId == 16
+    }
 
     def isEmpty: Boolean = blockchain.height == 0
 

--- a/src/main/scala/com/ltonetwork/state/package.scala
+++ b/src/main/scala/com/ltonetwork/state/package.scala
@@ -5,7 +5,7 @@ import com.ltonetwork.block.Block
 import com.ltonetwork.block.Block.BlockId
 import com.ltonetwork.transaction.ValidationError.GenericError
 import com.ltonetwork.transaction._
-import com.ltonetwork.transaction.association.AssociationTransaction
+import com.ltonetwork.transaction.association.{AssociationTransaction, IssueAssociationTransaction}
 import com.ltonetwork.transaction.lease.LeaseTransaction
 import com.ltonetwork.utils.ScorexLogging
 
@@ -48,9 +48,8 @@ package object state {
 
   implicit class BlockchainExt(blockchain: Blockchain) extends ScorexLogging {
     def assocExists(tx: AssociationTransaction): Boolean = {
-      blockchain.associations(tx.sender).outgoing.map(_._2).exists(as => tx.assoc == as.assoc) &&
-      // https://github.com/ltonetwork/lto-public-chain/issues/111
-      blockchain.associations(tx.sender).outgoing.map(_._2).maxBy(_.timestamp).typeId == 16
+      val txs = blockchain.associations(tx.sender).outgoing.map(_._2).filter(as => tx.assoc == as.assoc)
+      txs.nonEmpty && txs.maxBy(tx => (tx.timestamp, tx.typeId)).typeId == IssueAssociationTransaction.typeId
     }
 
     def isEmpty: Boolean = blockchain.height == 0


### PR DESCRIPTION
Order of tx in the block sometimes doesn't correspond to the time of insertion in LevelDB, thus sometimes revocation of association can be inserted before its invocation. When using `foldLeft` this clearly makes it an issue. Sorting the association transactions by type (that would be first invocations and then revocations) fixes this issue.

Closes #106 