### PR TITLE
Data tx entry int

### DIFF
--- a/src/main/scala/com/ltonetwork/state/DataEntry.scala
+++ b/src/main/scala/com/ltonetwork/state/DataEntry.scala
@@ -1,6 +1,6 @@
 package com.ltonetwork.state
 
-import com.google.common.primitives.{Longs, Shorts}
+import com.google.common.primitives.{Ints, Shorts}
 import com.ltonetwork.serialization.Deser
 import com.ltonetwork.state.DataEntry._
 import play.api.libs.json._
@@ -40,7 +40,7 @@ object DataEntry {
 
   def parseValue(key: String, bytes: Array[Byte], p: Int): (DataEntry[_], Int) = {
     bytes(p) match {
-      case t if t == Type.Integer.id => (IntegerDataEntry(key, Longs.fromByteArray(bytes.drop(p + 1))), p + 9)
+      case t if t == Type.Integer.id => (IntegerDataEntry(key, Ints.fromByteArray(bytes.drop(p + 1))), p + 5)
       case t if t == Type.Boolean.id => (BooleanDataEntry(key, bytes(p + 1) != 0), p + 2)
       case t if t == Type.Binary.id =>
         val (blob, p1) = Deser.parseArraySize(bytes, p + 1)
@@ -60,7 +60,7 @@ object DataEntry {
           jsv \ "type" match {
             case JsDefined(JsString("integer")) =>
               jsv \ "value" match {
-                case JsDefined(JsNumber(n)) => JsSuccess(IntegerDataEntry(key, n.toLong))
+                case JsDefined(JsNumber(n)) => JsSuccess(IntegerDataEntry(key, n.toInt))
                 case _                      => JsError("value is missing or not an integer")
               }
             case JsDefined(JsString("boolean")) =>
@@ -90,8 +90,8 @@ object DataEntry {
   }
 }
 
-case class IntegerDataEntry(override val key: String, override val value: Long) extends DataEntry[Long](key, value) {
-  override def valueBytes: Array[Byte] = Type.Integer.id.toByte +: Longs.toByteArray(value)
+case class IntegerDataEntry(override val key: String, override val value: Int) extends DataEntry[Int](key, value) {
+  override def valueBytes: Array[Byte] = Type.Integer.id.toByte +: Ints.toByteArray(value)
 
   override def toJson: JsObject = super.toJson + ("type" -> JsString("integer")) + ("value" -> JsNumber(value))
 }

--- a/src/test/scala/com/ltonetwork/TransactionGen.scala
+++ b/src/test/scala/com/ltonetwork/TransactionGen.scala
@@ -323,10 +323,10 @@ trait TransactionGenBase extends ScriptGen {
     size <- Gen.choose[Byte](1, MaxKeySize)
   } yield Random.alphanumeric.take(size).mkString
 
-  def longEntryGen(keyGen: Gen[String] = dataKeyGen): Gen[IntegerDataEntry] =
+  def intEntryGen(keyGen: Gen[String] = dataKeyGen): Gen[IntegerDataEntry] =
     for {
       key   <- keyGen
-      value <- Gen.choose[Long](Long.MinValue, Long.MaxValue)
+      value <- Gen.choose[Int](Int.MinValue, Int.MaxValue)
     } yield IntegerDataEntry(key, value)
 
   def booleanEntryGen(keyGen: Gen[String] = dataKeyGen): Gen[BooleanDataEntry] =
@@ -350,7 +350,7 @@ trait TransactionGenBase extends ScriptGen {
     } yield StringDataEntry(key, value.mkString)
 
   def dataEntryGen(maxSize: Int, keyGen: Gen[String] = dataKeyGen): Gen[DataEntry[_]] =
-    Gen.oneOf(longEntryGen(keyGen), booleanEntryGen(keyGen), binaryEntryGen(maxSize, keyGen), stringEntryGen(maxSize, keyGen))
+    Gen.oneOf(intEntryGen(keyGen), booleanEntryGen(keyGen), binaryEntryGen(maxSize, keyGen), stringEntryGen(maxSize, keyGen))
 
   def dataGen(size: Int): Gen[List[DataEntry[_]]] = {
     val maxEntrySize = ((DataTransaction.MaxBytes / (size max 1)) - DataEntry.MaxKeySize) min DataEntry.MaxValueSize

--- a/src/test/scala/com/ltonetwork/state/diffs/DataTransactionDiffTest.scala
+++ b/src/test/scala/com/ltonetwork/state/diffs/DataTransactionDiffTest.scala
@@ -30,7 +30,7 @@ class DataTransactionDiffTest extends AnyPropSpec with ScalaCheckDrivenPropertyC
       (genesis, master, ts) <- baseSetup
 
       key1   <- dataKeyGen
-      value1 <- positiveLongGen
+      value1 <- positiveIntGen
       item1 = IntegerDataEntry(key1, value1)
       fee1     <- smallFeeGen
       version1 = 3: Byte //<- Gen.oneOf(DataTransaction.supportedVersions.toSeq)
@@ -43,7 +43,7 @@ class DataTransactionDiffTest extends AnyPropSpec with ScalaCheckDrivenPropertyC
       version2 = 3: Byte //<- Gen.oneOf(DataTransaction.supportedVersions.toSeq)
       dataTx2 = data(version2, master, List(item2), fee2, ts + 20000)
 
-      value3 <- positiveLongGen
+      value3 <- positiveIntGen
       item3 = IntegerDataEntry(key1, value3)
       fee3     <- smallFeeGen
       version3 = 3: Byte //<- Gen.oneOf(DataTransaction.supportedVersions.toSeq)

--- a/src/test/scala/com/ltonetwork/transaction/DataTransactionSpecification.scala
+++ b/src/test/scala/com/ltonetwork/transaction/DataTransactionSpecification.scala
@@ -155,7 +155,7 @@ class DataTransactionSpecification extends AnyPropSpec with ScalaCheckDrivenProp
     val js = Json.parse("""{
                        "type": 12,
                        "version": 3,
-                       "id": "CsJPMx8MY3dLXKHu13zpL2vWfeU5mdDiyEF6APyKummd",
+                       "id": "BU6FbJ236n5qsmfv9XAdCaLzPA9mUk2nispnpDkpVmrd",
                        "sender": "3Mr31XDsqdktAdNQCdSd8ieQuYoJfsnLVFg",
                        "senderKeyType": "ed25519",
                        "senderPublicKey": "FM5ojNqW7e9cZ9zhPYGkpSP1Pcd8Z3e3MNKYVS5pGJ8Z",


### PR DESCRIPTION
Data transaction's entries were converting integers to longs, thus resulting in 8 bytes instead of 4.