### PR TITLE
DB migration for burned amount

### DIFF
--- a/src/main/scala/com/ltonetwork/Application.scala
+++ b/src/main/scala/com/ltonetwork/Application.scala
@@ -15,6 +15,7 @@ import com.ltonetwork.consensus.PoSSelector
 import com.ltonetwork.consensus.nxt.api.NxtConsensusApiRoute
 import com.ltonetwork.db.{DBExt, openDB}
 import com.ltonetwork.database.Keys
+import com.ltonetwork.database.migration.runMigrations
 import com.ltonetwork.features.api.ActivationApiRoute
 import com.ltonetwork.fee.{FeeCalculator, FeeVoteFileWatch}
 import com.ltonetwork.fee.api.FeesApiRoute
@@ -34,7 +35,7 @@ import io.netty.channel.group.DefaultChannelGroup
 import io.netty.util.concurrent.GlobalEventExecutor
 import kamon.Kamon
 import monix.eval.{Coeval, Task}
-import monix.execution.Scheduler.{singleThread, fixedPool, global}
+import monix.execution.Scheduler.{fixedPool, global, singleThread}
 import monix.execution.schedulers.SchedulerService
 import monix.reactive.Observable
 import monix.reactive.subjects.ConcurrentSubject
@@ -87,6 +88,7 @@ class Application(val actorSystem: ActorSystem, val settings: LtoSettings, confi
 
   def run(): Unit = {
     checkGenesis(settings, blockchainUpdater)
+    runMigrations(db, settings.blockchainSettings)
 
     if (wallet.privateKeyAccounts.isEmpty)
       wallet.generateNewAccounts(1)

--- a/src/main/scala/com/ltonetwork/database/Caches.scala
+++ b/src/main/scala/com/ltonetwork/database/Caches.scala
@@ -205,6 +205,8 @@ trait Caches extends Blockchain {
     heightCache = loadHeight()
     scoreCache = loadScore()
     lastBlockCache = loadLastBlock()
+    burnedCache = loadBurned()
+    feePriceCache.invalidateAll()
 
     activatedFeaturesCache = loadActivatedFeatures()
     approvedFeaturesCache = loadApprovedFeatures()

--- a/src/main/scala/com/ltonetwork/database/Keys.scala
+++ b/src/main/scala/com/ltonetwork/database/Keys.scala
@@ -121,4 +121,6 @@ object Keys {
 
   def feePrice(height: Int): Key[Option[Long]] = Key.opt[Long](h(50, height), Longs.fromByteArray, Longs.toByteArray)
   def burned(height: Int): Key[Long] = Key[Long](h(51, height), Option(_).fold(0L)(Longs.fromByteArray), Longs.toByteArray)
+
+  def migration(id: Int): Key[Int] = Key[Int](h(53, id), Option(_).fold(0)(Ints.fromByteArray), Ints.toByteArray)
 }

--- a/src/main/scala/com/ltonetwork/database/migration/Migration.scala
+++ b/src/main/scala/com/ltonetwork/database/migration/Migration.scala
@@ -1,0 +1,73 @@
+package com.ltonetwork.database.migration
+
+import com.ltonetwork.block.Block
+import com.ltonetwork.database.{Keys, RW, ReadOnlyDB}
+import com.ltonetwork.settings.{BlockchainSettings, FunctionalitySettings}
+import com.ltonetwork.utils.ScorexLogging
+import org.iq80.leveldb.{DB, ReadOptions}
+
+trait Migration extends ScorexLogging {
+  import Migration._
+
+  val id: Int
+  val description: String
+  val writableDB: DB
+  val fs: FunctionalitySettings
+
+  val currentHeight: Int = readOnly(_.get(Keys.migration(id)))
+  val maxHeight: Int = readOnly(_.get(Keys.height))
+
+  def isDone: Boolean = currentHeight >= SKIPPED
+  def isApplied: Boolean = currentHeight == APPLIED
+  def isSkipped: Boolean = currentHeight == SKIPPED
+
+  protected def setHeight(height: Int): Unit = readWrite(_.put(Keys.migration(id), height))
+
+  protected def readOnly[A](f: ReadOnlyDB => A): A = {
+    val s = writableDB.getSnapshot
+    try f(new ReadOnlyDB(writableDB, new ReadOptions().snapshot(s)))
+    finally s.close()
+  }
+
+  protected def readWrite[A](f: RW => A): A = {
+    val rw = new RW(writableDB)
+    try f(rw)
+    finally rw.close()
+  }
+
+  protected def before(): Unit = {}
+  protected def after(): Unit = {}
+
+  protected def applyTo(height: Int, block: Block): Unit
+
+  protected def apply(): Unit = {
+    if (currentHeight == 0) before()
+
+    log.info(s"${description} from block ${currentHeight + 1} to ${maxHeight}")
+
+    for (height <- Range.inclusive(currentHeight + 1, maxHeight)) {
+      val block = readOnly(_.get(Keys.blockAt(height))).get
+      if (height % 10000 == 0)
+        log.info(s"Block ${height}")
+
+      applyTo(height, block)
+      setHeight(height)
+    }
+
+    after()
+  }
+
+  def run(): Unit = {
+    if (maxHeight == 0) {
+      setHeight(Migration.SKIPPED)
+    } else if (!isDone) {
+      apply()
+      setHeight(Migration.APPLIED)
+    }
+  }
+}
+
+object Migration {
+  val SKIPPED: Int = Int.MaxValue - 1
+  val APPLIED: Int = Int.MaxValue
+}

--- a/src/main/scala/com/ltonetwork/database/migration/package.scala
+++ b/src/main/scala/com/ltonetwork/database/migration/package.scala
@@ -1,0 +1,10 @@
+package com.ltonetwork.database
+
+import com.ltonetwork.settings.BlockchainSettings
+import org.iq80.leveldb.DB
+
+package object migration {
+  def runMigrations(writableDB: DB, settings: BlockchainSettings): Unit = {
+    CalculateBurnMigration(writableDB, settings.functionalitySettings).run()
+  }
+}

--- a/src/main/scala/com/ltonetwork/utils/ApplicationStopReason.scala
+++ b/src/main/scala/com/ltonetwork/utils/ApplicationStopReason.scala
@@ -3,3 +3,4 @@ package com.ltonetwork.utils
 sealed abstract class ApplicationStopReason(val code: Int)
 case object Default            extends ApplicationStopReason(1)
 case object UnsupportedFeature extends ApplicationStopReason(38)
+case object MigrationError     extends ApplicationStopReason(39)


### PR DESCRIPTION
DB migration to calculate burned amount for each block.
This updates leveldb for 1.5, so a sync from genesis is not required.