### PR TITLE
Fix mining reward calculation.

### DIFF
--- a/src/main/scala/com/ltonetwork/features/FeatureProvider.scala
+++ b/src/main/scala/com/ltonetwork/features/FeatureProvider.scala
@@ -20,6 +20,7 @@ object FeatureProvider {
     def featureActivationHeight(feature: BlockchainFeature): Option[Int] = provider.activatedFeatures.get(feature.id)
     def featureActivationHeight(feature: Short): Option[Int] = provider.activatedFeatures.get(feature)
 
-    def featureApprovalHeight(feature: Short): Option[Int]   = provider.approvedFeatures.get(feature)
+    def featureApprovalHeight(feature: BlockchainFeature): Option[Int] = provider.approvedFeatures.get(feature.id)
+    def featureApprovalHeight(feature: Short): Option[Int] = provider.approvedFeatures.get(feature)
   }
 }

--- a/src/main/scala/com/ltonetwork/settings/FunctionalitySettings.scala
+++ b/src/main/scala/com/ltonetwork/settings/FunctionalitySettings.scala
@@ -51,7 +51,7 @@ object FunctionalitySettings {
     blocksForFeeChange = 600,
     miningReward = 10L * 10^8,
     miningRewardBonus = 1000L,
-    miningRewardBonusPeriod = 25000000,
+    miningRewardBonusPeriod = 2500000,
     leaseUnbondingPeriod = 3000,
     burnAddresses = Set("3JrGV6TeEV3ovVjsh9SPqQL48EDLET47B9U")
   )
@@ -65,7 +65,7 @@ object FunctionalitySettings {
     blocksForFeeChange = 600,
     miningReward = 10L * 10^8,
     miningRewardBonus = 1000L,
-    miningRewardBonusPeriod = 25000000,
+    miningRewardBonusPeriod = 2500000,
     leaseUnbondingPeriod = 1000,
     burnAddresses = Set("3N3pCgpW1cB1Ns56yjPFmXfBSUjNZ1cYroE")
   )


### PR DESCRIPTION
Mining bonus reward period is 2.5M blocks, not 25M blocks.
Don't assume that when the activation height is known, the feature is activated. This isn't true; the activation height can be a future block