### PR TITLE
Fix for JUICY fork when synced from genesis

### DIFF
--- a/src/main/scala/com/ltonetwork/block/Block.scala
+++ b/src/main/scala/com/ltonetwork/block/Block.scala
@@ -9,7 +9,7 @@ import com.ltonetwork.state._
 import com.ltonetwork.transaction.ValidationError.GenericError
 import com.ltonetwork.transaction._
 import com.ltonetwork.transaction.genesis.GenesisTransaction
-import com.ltonetwork.utils.ScorexLogging
+import com.ltonetwork.utils.{Fraction, ScorexLogging}
 import monix.eval.Coeval
 import play.api.libs.json.{JsObject, Json}
 import scorex.crypto.signatures.Curve25519._
@@ -72,20 +72,8 @@ case class Block private (override val timestamp: Long,
 }
 
 object Block extends ScorexLogging {
-
-  trait Fraction {
-    def apply(l: Long): Long;
-  }
-  case class PositiveFraction(dividend: Int, divider: Int) extends Fraction {
-    def apply(l: Long): Long = l / divider * dividend
-  }
-  case class NegativeFraction(dividend: Int, divider: Int) extends Fraction {
-    private val inv = PositiveFraction(divider - dividend, divider)
-    def apply(l: Long): Long = l - inv(l)
-  }
-
-  val OpenerBlockFeePart: Fraction = PositiveFraction(2, 5)
-  val CloserBlockFeePart: Fraction = NegativeFraction(3, 5)
+  val OpenerBlockFeePart: Fraction = Fraction.roundDown(2, 5)
+  val CloserBlockFeePart: Fraction = Fraction.roundUp(3, 5)
 
   type BlockIds = Seq[ByteStr]
   type BlockId = ByteStr

--- a/src/main/scala/com/ltonetwork/block/Block.scala
+++ b/src/main/scala/com/ltonetwork/block/Block.scala
@@ -77,7 +77,8 @@ object Block extends ScorexLogging {
     def apply(l: Long): Long = l / divider * dividend
   }
 
-  val CurrentBlockFeePart: Fraction = Fraction(2, 5)
+  val OpenerBlockFeePart: Fraction = Fraction(2, 5)
+  val CloserBlockFeePart: Fraction = Fraction(3, 5)
 
   type BlockIds = Seq[ByteStr]
   type BlockId = ByteStr

--- a/src/main/scala/com/ltonetwork/block/Block.scala
+++ b/src/main/scala/com/ltonetwork/block/Block.scala
@@ -73,12 +73,19 @@ case class Block private (override val timestamp: Long,
 
 object Block extends ScorexLogging {
 
-  case class Fraction(dividend: Int, divider: Int) {
+  trait Fraction {
+    def apply(l: Long): Long;
+  }
+  case class PositiveFraction(dividend: Int, divider: Int) extends Fraction {
     def apply(l: Long): Long = l / divider * dividend
   }
+  case class NegativeFraction(dividend: Int, divider: Int) extends Fraction {
+    private val inv = PositiveFraction(divider - dividend, divider)
+    def apply(l: Long): Long = l - inv(l)
+  }
 
-  val OpenerBlockFeePart: Fraction = Fraction(2, 5)
-  val CloserBlockFeePart: Fraction = Fraction(3, 5)
+  val OpenerBlockFeePart: Fraction = PositiveFraction(2, 5)
+  val CloserBlockFeePart: Fraction = NegativeFraction(3, 5)
 
   type BlockIds = Seq[ByteStr]
   type BlockId = ByteStr

--- a/src/main/scala/com/ltonetwork/database/migration/CalculateBurnMigration.scala
+++ b/src/main/scala/com/ltonetwork/database/migration/CalculateBurnMigration.scala
@@ -16,7 +16,8 @@ case class CalculateBurnMigration(writableDB: DB, fs: FunctionalitySettings) ext
 
   var burned: Long = 0L
 
-  val burnFeetureHeight: Int = readOnly(_.get(Keys.activatedFeatures)).getOrElse(BlockchainFeatures.BurnFeeture.id, Int.MaxValue)
+  val burnFeetureHeight: Int = readOnly(_.get(Keys.activatedFeatures))
+    .get(BlockchainFeatures.BurnFeeture.id).fold(Int.MaxValue)(_ + 1)
 
   def isBurnAddress(address: Address): Boolean = fs.burnAddresses.contains(address.toString)
 

--- a/src/main/scala/com/ltonetwork/database/migration/CalculateBurnMigration.scala
+++ b/src/main/scala/com/ltonetwork/database/migration/CalculateBurnMigration.scala
@@ -1,5 +1,6 @@
 package com.ltonetwork.database.migration
 import com.ltonetwork.account.Address
+import com.ltonetwork.block.Block.{CloserBlockFeePart, OpenerBlockFeePart}
 import com.ltonetwork.block.{Block, BlockRewardCalculator}
 import com.ltonetwork.database.Keys
 import com.ltonetwork.features.BlockchainFeatures
@@ -17,7 +18,7 @@ case class CalculateBurnMigration(writableDB: DB, fs: FunctionalitySettings) ext
   var burned: Long = 0L
 
   val burnFeetureHeight: Int = readOnly(_.get(Keys.activatedFeatures))
-    .get(BlockchainFeatures.BurnFeeture.id).fold(Int.MaxValue)(_ + 1)
+    .getOrElse(BlockchainFeatures.BurnFeeture.id, Int.MaxValue)
 
   def isBurnAddress(address: Address): Boolean = fs.burnAddresses.contains(address.toString)
 
@@ -32,8 +33,10 @@ case class CalculateBurnMigration(writableDB: DB, fs: FunctionalitySettings) ext
     }).toLong)
 
   protected def transactionBurn(height: Int, block: Block): Long =
-    if (height >= burnFeetureHeight)
+    if (height > burnFeetureHeight)
       block.transactionCount * BlockRewardCalculator.feeBurnAmt
+    else if (height == burnFeetureHeight)
+      CloserBlockFeePart(block.transactionCount * BlockRewardCalculator.feeBurnAmt)
     else
       0L
 

--- a/src/main/scala/com/ltonetwork/state/Portfolio.scala
+++ b/src/main/scala/com/ltonetwork/state/Portfolio.scala
@@ -1,7 +1,7 @@
 package com.ltonetwork.state
 
 import cats._
-import com.ltonetwork.block.Block.Fraction
+import com.ltonetwork.utils.Fraction
 
 case class Portfolio(balance: Long, lease: LeaseBalance) {
   lazy val effectiveBalance: Long = safeSum(balance, lease.in) - lease.out

--- a/src/main/scala/com/ltonetwork/state/diffs/BlockDiffer.scala
+++ b/src/main/scala/com/ltonetwork/state/diffs/BlockDiffer.scala
@@ -3,7 +3,7 @@ package com.ltonetwork.state.diffs
 import cats.Monoid
 import cats.implicits._
 import com.ltonetwork.account.Address
-import com.ltonetwork.block.Block.CurrentBlockFeePart
+import com.ltonetwork.block.Block.OpenerBlockFeePart
 import com.ltonetwork.block.{Block, BlockRewardCalculator, MicroBlock}
 import com.ltonetwork.metrics.Instrumented
 import com.ltonetwork.mining.MiningConstraint
@@ -102,7 +102,7 @@ object BlockDiffer extends ScorexLogging with Instrumented {
           else
             txDiffer(updatedBlockchain, tx).map { newDiff =>
               val updatedDiff  = currDiff.combine(newDiff)
-              val curBlockFees = BlockRewardCalculator.rewardedFee(blockchain, currentBlockHeight, tx).multiply(CurrentBlockFeePart)
+              val curBlockFees = BlockRewardCalculator.rewardedFee(blockchain, currentBlockHeight, tx).multiply(OpenerBlockFeePart)
               val burnedFees   = BlockRewardCalculator.burnedFee(blockchain, currentBlockHeight, tx)
               val diff         = updatedDiff.combine(Diff.empty.copy(
                 portfolios = Map(blockGenerator -> curBlockFees),

--- a/src/main/scala/com/ltonetwork/state/diffs/BlockDiffer.scala
+++ b/src/main/scala/com/ltonetwork/state/diffs/BlockDiffer.scala
@@ -30,7 +30,7 @@ object BlockDiffer extends ScorexLogging with Instrumented {
     val miningReward = BlockRewardCalculator.miningReward(settings, blockchain)
     val initDiff = Diff.empty.copy(
       portfolios = Map(blockGenerator.toAddress -> Monoid[Portfolio].combine(
-        maybePrevBlock.map(b => BlockRewardCalculator.openerBlockFee(blockchain, stateHeight, b)).orEmpty, // NG reward for closing block
+        maybePrevBlock.map(b => BlockRewardCalculator.closerBlockFee(blockchain, stateHeight, b)).orEmpty, // NG reward for closing block
         miningReward,
       )),
       burned = -1 * miningReward.balance

--- a/src/main/scala/com/ltonetwork/utils/Fraction.scala
+++ b/src/main/scala/com/ltonetwork/utils/Fraction.scala
@@ -1,0 +1,19 @@
+package com.ltonetwork.utils
+
+trait Fraction {
+  def apply(l: Long): Long;
+}
+
+object Fraction {
+  private case class RoundDownFraction(dividend: Int, divider: Int) extends Fraction {
+    def apply(l: Long): Long = l / divider * dividend
+  }
+
+  private case class RoundUpFraction(dividend: Int, divider: Int) extends Fraction {
+    private val inv = RoundDownFraction(divider - dividend, divider)
+    def apply(l: Long): Long = l - inv(l)
+  }
+
+  def roundDown(dividend: Int, divider: Int): Fraction = RoundDownFraction(dividend, divider)
+  def roundUp(dividend: Int, divider: Int): Fraction = RoundUpFraction(dividend, divider)
+}

--- a/src/test/scala/com/ltonetwork/state/diffs/SponsoredTransactionDiffTest.scala
+++ b/src/test/scala/com/ltonetwork/state/diffs/SponsoredTransactionDiffTest.scala
@@ -77,7 +77,7 @@ class SponsoredTransactionDiffTest
             d.portfolios(sponsorship.sender.toAddress).balance shouldBe (-transfer.fee)
             d.portfolios(transfer.sender.toAddress).balance shouldBe (-transfer.amount)
             d.portfolios(transfer.recipient).balance shouldBe transfer.amount
-            val fees = Block.CurrentBlockFeePart(transfer.fee) + sponsorship.fee - Block.CurrentBlockFeePart(sponsorship.fee)
+            val fees = Block.OpenerBlockFeePart(transfer.fee) + sponsorship.fee - Block.OpenerBlockFeePart(sponsorship.fee)
             d.portfolios(TestBlock.defaultSigner).balance shouldBe fees
             b.sponsorOf(transfer.sender.toAddress) shouldBe List(sponsorship.sender.toAddress)
         }
@@ -159,7 +159,7 @@ class SponsoredTransactionDiffTest
             d.portfolios(sponsor.toAddress).balance shouldBe (-transfer.fee)
             d.portfolios(sponsoredTransfer.sender.toAddress).balance shouldBe (-transfer.amount)
             d.portfolios(sponsoredTransfer.recipient).balance shouldBe transfer.amount
-            val fees = Block.CurrentBlockFeePart(sponsoredTransfer.fee)
+            val fees = Block.OpenerBlockFeePart(sponsoredTransfer.fee)
             d.portfolios(TestBlock.defaultSigner).balance shouldBe fees
         }
     }
@@ -175,7 +175,7 @@ class SponsoredTransactionDiffTest
             d.portfolios(sponsor.toAddress).balance shouldBe (-transfer.fee)
             d.portfolios(sponsoredTransfer.sender.toAddress).balance shouldBe (-transfer.amount)
             d.portfolios(sponsoredTransfer.recipient).balance shouldBe transfer.amount
-            val fees = Block.CurrentBlockFeePart(transfer.fee) + sponsorship.fee - Block.CurrentBlockFeePart(sponsorship.fee)
+            val fees = Block.OpenerBlockFeePart(transfer.fee) + sponsorship.fee - Block.OpenerBlockFeePart(sponsorship.fee)
             d.portfolios(TestBlock.defaultSigner).balance shouldBe fees
             b.sponsorOf(transfer.sender.toAddress) shouldBe List(sponsorship.sender.toAddress)
         }
@@ -195,7 +195,7 @@ class SponsoredTransactionDiffTest
             d.portfolios(sponsor.toAddress).balance shouldBe (-transfer.fee)
             d.portfolios(sponsoredTransfer.sender.toAddress).balance shouldBe (-transfer.amount)
             d.portfolios(sponsoredTransfer.recipient).balance shouldBe transfer.amount
-            val fees = Block.CurrentBlockFeePart(transfer.fee) + setScript.fee - Block.CurrentBlockFeePart(setScript.fee)
+            val fees = Block.OpenerBlockFeePart(transfer.fee) + setScript.fee - Block.OpenerBlockFeePart(setScript.fee)
             d.portfolios(TestBlock.defaultSigner).balance shouldBe fees
         }
     }


### PR DESCRIPTION
For reward calculation, the burn feature needs to be activated before the block is opened.
During activation part of the fees are burned and part aren't.