### PR TITLE
Checkpoints configuration

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -198,7 +198,10 @@ lto {
   # Checkpoints settings
   checkpoints {
     # Public key for checkpoints verification, default TESTNET public key
-    public-key = "3yDuDkgDiBLnNN9wPzNT57ZotmJCax7FLcXvgGWLXdJH"
+    # public-key = "3yDuDkgDiBLnNN9wPzNT57ZotmJCax7FLcXvgGWLXdJH"
+
+    blocks = [
+    ]
   }
 
   # Transaction fees for different types of transactions

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -197,9 +197,16 @@ lto {
 
   # Checkpoints settings
   checkpoints {
-    # Public key for checkpoints verification, default TESTNET public key
+    # Public key for checkpoints verification. Not recommended to use outside of debug purposes.
     # public-key = "3yDuDkgDiBLnNN9wPzNT57ZotmJCax7FLcXvgGWLXdJH"
 
+    # List of block height and signature combinations to ensure the blockchain follows the main branch and not a fork.
+    #
+    #   blocks = [
+    #     {height = 870000, signature = "Y3j4WStUrhF43UXTi4NPSvc23joyar49MhFCHZXVEmvh9fu6Hw33LtouspSgKE3xXQVAgFt4V6QeBxiuoGK5qas"},
+    #     {height = 1762697, signature = "2ddsSGaTqg8iRKcQCSMBmgmzWrMpesURydSJmBprm1d5JqghcvUjT9YBAL6r19Y9wr9FTktmxjZQPUU2DcB8826w"}
+    #   ]
+    #
     blocks = [
     ]
   }

--- a/src/main/scala/com/ltonetwork/Application.scala
+++ b/src/main/scala/com/ltonetwork/Application.scala
@@ -63,7 +63,7 @@ class Application(val actorSystem: ActorSystem, val settings: LtoSettings, confi
     Wallet(settings.walletSettings)
   } catch {
     case e: IllegalStateException =>
-      log.error(s"Failed to open wallet file '${settings.walletSettings.file.get.getAbsolutePath}")
+      log.error(s"Failed to open wallet file '${settings.walletSettings.file.get.getAbsolutePath}'")
       throw e
   }
   private val peerDatabase = new PeerDatabaseImpl(settings.networkSettings)

--- a/src/main/scala/com/ltonetwork/network/Checkpoint.scala
+++ b/src/main/scala/com/ltonetwork/network/Checkpoint.scala
@@ -5,11 +5,18 @@ import com.ltonetwork.utils.Base58
 import io.swagger.v3.oas.annotations.media.Schema
 import play.api.libs.json._
 import scorex.crypto.signatures.Curve25519._
+import java.util.Objects
 
-import scala.collection.immutable.Stream
 import scala.util.{Failure, Success}
 
-case class BlockCheckpoint(height: Int, @Schema(`type` = "java.lang.String") signature: Array[Byte])
+case class BlockCheckpoint(height: Int, @Schema(`type` = "java.lang.String") signature: Array[Byte]) {
+  override def equals(b: Any): Boolean = b match {
+    case other: BlockCheckpoint => height == other.height && signature.sameElements(other.signature)
+    case _                      => false
+  }
+
+  override def hashCode(): Int = Objects.hash(Int.box(height), signature)
+}
 
 case class Checkpoint(items: Seq[BlockCheckpoint], @Schema(`type` = "java.lang.String") signature: Array[Byte]) {
   def toSign: Array[Byte] = {

--- a/src/main/scala/com/ltonetwork/settings/CheckpointsSettings.scala
+++ b/src/main/scala/com/ltonetwork/settings/CheckpointsSettings.scala
@@ -1,17 +1,28 @@
 package com.ltonetwork.settings
 
+import com.ltonetwork.network.BlockCheckpoint
 import com.typesafe.config.Config
 import com.ltonetwork.state.ByteStr
+import com.ltonetwork.utils.Base58
 import net.ceedubs.ficus.Ficus._
+import net.ceedubs.ficus.readers.ValueReader
 
-case class CheckpointsSettings(publicKey: ByteStr)
+case class CheckpointsSettings(publicKey: Option[ByteStr], blocks: Seq[BlockCheckpoint])
 
 object CheckpointsSettings {
   val configPath: String = "lto.checkpoints"
 
   def fromConfig(config: Config): CheckpointsSettings = {
-    val publicKey = config.as[ByteStr](s"$configPath.public-key")
+    val publicKey = config.as[Option[ByteStr]](s"$configPath.public-key")
+    val blocks = config.as[Seq[BlockCheckpoint]](s"$configPath.blocks")
 
-    CheckpointsSettings(publicKey)
+    CheckpointsSettings(publicKey, blocks)
+  }
+
+  implicit val checkpointReader: ValueReader[BlockCheckpoint] = ValueReader.relative { block =>
+    BlockCheckpoint(
+      block.as[Int]("height"),
+      Base58.decode(block.as[String]("signature")).get
+    )
   }
 }

--- a/src/main/scala/com/ltonetwork/state/appender/package.scala
+++ b/src/main/scala/com/ltonetwork/state/appender/package.scala
@@ -23,8 +23,6 @@ package object appender extends ScorexLogging {
 
   // Invalid blocks, that are already in blockchain
   private val exceptions = List(
-    812608 -> ByteStr.decodeBase58("2GNCYVy7k3kEPXzz12saMtRDeXFKr8cymVsG8Yxx3sZZ75eHj9csfXnGHuuJe7XawbcwjKdifUrV1uMq4ZNCWPf1").get,
-    813207 -> ByteStr.decodeBase58("5uZoDnRKeWZV9Thu2nvJVZ5dBvPB7k2gvpzFD618FMXCbBVBMN2rRyvKBZBhAGnGdgeh2LXEeSr9bJqruJxngsE7").get
   )
 
   private[appender] def processAndBlacklistOnFailure[A, B](

--- a/src/main/scala/com/ltonetwork/transaction/CheckpointService.scala
+++ b/src/main/scala/com/ltonetwork/transaction/CheckpointService.scala
@@ -7,18 +7,16 @@ trait CheckpointService {
 
   def set(checkpoint: Checkpoint): Either[ValidationError, Unit]
 
-  def get: Option[Checkpoint]
+  def get: Checkpoint
 }
 
 object CheckpointService {
 
   implicit class CheckpointServiceExt(cs: CheckpointService) {
     def isBlockValid(candidateSignature: ByteStr, estimatedHeight: Int): Boolean =
-      !cs.get.exists {
-        _.items.exists {
-          case BlockCheckpoint(h, sig) =>
-            h == estimatedHeight && candidateSignature != ByteStr(sig)
-        }
+      !cs.get.items.exists {
+        case BlockCheckpoint(h, sig) =>
+          h == estimatedHeight && candidateSignature != ByteStr(sig)
       }
   }
 

--- a/src/test/scala/com/ltonetwork/settings/CheckpointsSettingsSpecification.scala
+++ b/src/test/scala/com/ltonetwork/settings/CheckpointsSettingsSpecification.scala
@@ -1,7 +1,8 @@
 package com.ltonetwork.settings
 
+import com.ltonetwork.network.BlockCheckpoint
 import com.typesafe.config.ConfigFactory
-import com.ltonetwork.state.ByteStr
+import com.ltonetwork.utils.Base58
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -10,12 +11,19 @@ class CheckpointsSettingsSpecification extends AnyFlatSpec with Matchers {
     val config   = ConfigFactory.parseString("""
         |lto {
         |  checkpoints {
-        |    public-key: "BASE58PUBKEY"
+        |    public-key = "BASE58PUBKEY"
+        |    blocks = [
+        |       { height: 1, signature: 47pP5r1Kh159XmxcfG2eQVj6dKNhub3mvGgpJovcw7EcZyJswFLYyKGYNV21BGJ8pwkajA75ZLMWFBdv3BzMRMk },
+        |       { height: 300, signature: 4zU5E7VPwwoVpiEgGHnB9Qo5CLVgerKzXe1ny1NpkhrbB7Kgi7y3YV3qQNi1ct5zrGVuKxRAALXNEACtGcBhDDVg }
+        |    ]
         |  }
         |}
       """.stripMargin).resolve()
     val settings = CheckpointsSettings.fromConfig(config)
 
-    settings.publicKey should be(ByteStr.decodeBase58("BASE58PUBKEY").get)
+    settings.blocks should be(Seq(
+      BlockCheckpoint(1, Base58.decode("47pP5r1Kh159XmxcfG2eQVj6dKNhub3mvGgpJovcw7EcZyJswFLYyKGYNV21BGJ8pwkajA75ZLMWFBdv3BzMRMk").get),
+      BlockCheckpoint(300, Base58.decode("4zU5E7VPwwoVpiEgGHnB9Qo5CLVgerKzXe1ny1NpkhrbB7Kgi7y3YV3qQNi1ct5zrGVuKxRAALXNEACtGcBhDDVg").get),
+    ))
   }
 }


### PR DESCRIPTION
Partially solves #141

It allows halting on a specific block, which is useful for debugging.
Broadcasting a checkpoint is still available, but ignored by default because no public key is set.

Checkpoints still only work for blocks that are being added and don't force a rollback.