### PR TITLE
Fix value of generatorReward in block API endpoints

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,7 @@ inConfig(Universal)(
         case other => other
       }
     },
-    mappings += (baseDirectory.value / s"fee-vote.py" -> "bin/lto-fee-vote"),
+    mappings += (baseDirectory.value / s"fee-vote.py" -> s"bin/lto${network.value.packageSuffix}-fee-vote"),
     javaOptions ++= Seq(
       // -J prefix is required by the bash script
       "-J-server",

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -262,65 +262,6 @@ lto {
     }
   }
 
-  # Matcher settings
-  matcher {
-    # Enable/disable matcher
-    enable = no
-
-    # Matcher's account address
-    account = ""
-
-    # Matcher REST API bind address
-    bind-address = "127.0.0.1"
-
-    # Matcher REST API port
-    port = 6886
-
-    # Minimum allowed order fee
-    min-order-fee = 300000
-
-    # Fee of order match transaction
-    order-match-tx-fee = 300000
-
-    # Matcher's directories
-    matcher-directory = ${lto.directory}"/matcher"
-    data-directory = ${lto.matcher.matcher-directory}"/data"
-    journal-directory = ${lto.matcher.matcher-directory}"/journal"
-    snapshots-directory = ${lto.matcher.matcher-directory}"/snapshots"
-
-    # Snapshots creation interval
-    snapshots-interval = 1d
-
-    # Invalid/Expired orders cleanup interval
-    order-cleanup-interval = 5m
-
-    # Maximum allowed amount of orders retrieved via REST
-    rest-order-limit = 100
-
-    # Base assets used as price assets
-    price-assets: []
-
-    # Maximum difference with Matcher server time
-    max-timestamp-diff = 30d
-
-    # Blacklisted assets id
-    blacklisted-assets: []
-
-    # Blacklisted assets name
-    blacklisted-names: []
-
-    # Blacklisted addresses
-    blacklisted-addresses: []
-
-    # If enabled, the matcher cancels orders, which become invalid because of transfer and leasing transactions
-    balance-watching {
-      enable = no
-
-      # If the timeout has been reached, a balance watcher actor ends processing orders
-      one-address-processing-timeout = 60s
-    }
-  }
-
   # New blocks generator settings
   miner {
     # Enable/disable block generation

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -446,15 +446,6 @@ metrics {
 
 # WARNING: No user-configurable settings below this line.
 
-
-lto.matcher.snapshot-store {
-  class = "com.ltonetwork.matcher.MatcherSnapshotStore"
-  plugin-dispatcher = "akka.persistence.dispatchers.default-plugin-dispatcher"
-  stream-dispatcher = "akka.persistence.dispatchers.default-stream-dispatcher"
-  dir = ${lto.matcher.snapshots-directory}
-  leveldb-dir = ${lto.matcher.matcher-directory}/leveldb-snapshots
-}
-
 akka {
   loglevel = "DEBUG"
   loggers = ["akka.event.slf4j.Slf4jLogger"]
@@ -469,16 +460,5 @@ akka {
   io.tcp {
     direct-buffer-size = 1536 KiB
     trace-logging = off
-  }
-
-  persistence {
-    journal {
-      plugin = akka.persistence.journal.leveldb
-      leveldb {
-        dir = ${lto.matcher.journal-directory}
-        native = on
-      }
-    }
-    snapshot-store.plugin = lto.matcher.snapshot-store
   }
 }

--- a/src/main/scala/com/ltonetwork/api/BlocksApiRoute.scala
+++ b/src/main/scala/com/ltonetwork/api/BlocksApiRoute.scala
@@ -43,8 +43,8 @@ case class BlocksApiRoute(settings: RestAPISettings,
 
   private def blockJson(height: Int, block: Block) = {
     val miningReward = BlockRewardCalculator.miningReward(functionalitySettings, blockchain, height).balance
-    val prevBlockFee = blockchain.blockAt(height - 1).map(BlockRewardCalculator.openerBlockFee(blockchain, height, _).balance).getOrElse(0L)
-    val curBlockFee = BlockRewardCalculator.closerBlockFee(blockchain, height, block).balance
+    val prevBlockFee = blockchain.blockAt(height - 1).map(BlockRewardCalculator.closerBlockFee(blockchain, height - 1, _).balance).getOrElse(0L)
+    val curBlockFee = BlockRewardCalculator.openerBlockFee(blockchain, height, block).balance
     val feeCalculator = FeeCalculator(blockchain)
     val jsonHeight: JsValue = if (height > 0) JsNumber(height) else JsNull;
 

--- a/src/main/scala/com/ltonetwork/api/BlocksApiRoute.scala
+++ b/src/main/scala/com/ltonetwork/api/BlocksApiRoute.scala
@@ -99,13 +99,10 @@ case class BlocksApiRoute(settings: RestAPISettings,
               (blockchain.blockAt(height), height)
             }
             .filter(_._1.isDefined)
-            .map { pair =>
-              (pair._1.get, pair._2)
-            }
+            .map { case (block, height) => (block.get, pair._2) }
             .filter(_._1.signerData.generator.address == address)
-            .map { pair =>
-              pair._1.json() + ("height" -> Json.toJson(pair._2))
-            })
+            .map { case (block, height) => blockJson(height, block) }
+        )
         complete(blocks)
       } else complete(TooBigArrayAllocation)
   }

--- a/src/main/scala/com/ltonetwork/api/BlocksApiRoute.scala
+++ b/src/main/scala/com/ltonetwork/api/BlocksApiRoute.scala
@@ -99,7 +99,7 @@ case class BlocksApiRoute(settings: RestAPISettings,
               (blockchain.blockAt(height), height)
             }
             .filter(_._1.isDefined)
-            .map { case (block, height) => (block.get, pair._2) }
+            .map { case (block, height) => (block.get, height) }
             .filter(_._1.signerData.generator.address == address)
             .map { case (block, height) => blockJson(height, block) }
         )


### PR DESCRIPTION
Fix incorrect generatorReward in block API.
Opener and closer fee was swapped.

Fee vote script in deb package should include package suffix

Return block rewards in `/blocks/address/{addr}/{from}/{to}` endpoint