### PR TITLE
Improve `/transactions/address` API endpoint

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,7 @@
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport.toPlatformDepsGroupID
 import sbt._
 
+//noinspection TypeAnnotation,ScalaStyle
 object Dependencies {
 
   val excludeScalaTest = ExclusionRule(organization = "org.scalatest")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,8 +41,9 @@ object Dependencies {
   )
 
   lazy val serialization = Seq(
-    "com.google.guava"  % "guava"      % "21.0",
-    "com.typesafe.play" %% "play-json" % "2.6.9"
+    "com.google.guava"  % "guava"         % "21.0",
+    "com.google.guava"  % "failureaccess" % "1.0.1",
+    "com.typesafe.play" %% "play-json"    % "2.6.9"
   )
   lazy val akka = Seq("actor", "slf4j", "actor-typed", "serialization-jackson").map(akkaModule)
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -5,11 +5,17 @@ lto {
   directory = ${user.home}"/lto"
   data-directory = ${lto.directory}"/data"
 
-  # Limits the size of caches which are used during block validation. Lower values slightly decrease memory consummption,
-  # while higher values might increase node performance. Setting ghis value to 0 disables caching alltogether.
+  # Limits the size of caches which are used during block validation. Lower values slightly decrease memory consumption,
+  # while higher values might increase node performance. Setting this value to 0 disables caching all together.
   max-cache-size = 100000
 
+  # The state history depth limits the number of blocks the blockchain can roll back for reorganizing. It also limits
+  # the `/address/balance/history` and `/debug/stateAtHeight` API endpoints.
   max-rollback-depth = 2000
+
+  # By default only transactions that modify the portfolio are indexed for an address. Set to true to index txs of all
+  # type for addresses.
+  index-all-transactions = false
 
   # P2P Network settings
   network {

--- a/src/main/scala/com/ltonetwork/database/LevelDBWriter.scala
+++ b/src/main/scala/com/ltonetwork/database/LevelDBWriter.scala
@@ -496,7 +496,7 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings, val maxCacheSize:
         (h, tx) <- db.get(Keys.transactionInfo(txId))
       } yield (h, tx)
 
-      txs.slice(from, count).force
+      txs.slice(from, from + count).force
     }
   }
 

--- a/src/main/scala/com/ltonetwork/database/LevelDBWriter.scala
+++ b/src/main/scala/com/ltonetwork/database/LevelDBWriter.scala
@@ -28,18 +28,15 @@ object LevelDBWriter {
     db.get(Keys.leaseStatusHistory(leaseId)).headOption.fold(false)(h => db.get(Keys.leaseStatus(leaseId)(h)))
 
   /** {{{
-    * ([10, 7, 4], 5, 11) => [10, 7, 4]
-    * ([10, 7], 5, 11) => [10, 7, 1]
-    * }}}
-    */
+   * ([10, 7, 4], 5, 11) => [10, 7, 4]
+   * ([10, 7], 5, 11) => [10, 7, 1]
+   * }}}
+   */
   private[database] def slice(v: Seq[Int], from: Int, to: Int): Seq[Int] = {
     val (c1, c2) = v.dropWhile(_ > to).partition(_ > from)
     c1 :+ c2.headOption.getOrElse(1)
   }
 
-  /**
-    * @todo move this method to `object LevelDBWriter` once SmartAccountTrading is activated
-    */
   private[database] def merge(wbh: Seq[Int], lbh: Seq[Int]): Seq[(Int, Int)] = {
 
     /**
@@ -88,7 +85,11 @@ object LevelDBWriter {
   }
 }
 
-class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings, val maxCacheSize: Int = 100000, val maxRollbackDepth: Int = 2000)
+class LevelDBWriter(writableDB: DB,
+                    fs: FunctionalitySettings,
+                    val maxCacheSize: Int = 100000,
+                    val maxRollbackDepth: Int = 2000,
+                    val indexAllTransactions: Boolean = false)
     extends Caches
     with ScorexLogging {
 
@@ -292,12 +293,14 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings, val maxCacheSize:
       }
     }
 
-    for ((addressId, txs) <- addressTransactions) {
-      val kk                          = Keys.addressTransactionSeqNr(addressId)
-      val nextSeqNr                   = rw.get(kk) + 1
-      val t: Key[Seq[(Int, AssetId)]] = Keys.addressTransactionIds(addressId, nextSeqNr)
-      rw.put(t, txs)
-      rw.put(kk, nextSeqNr)
+    addressTransactions.foreach {
+      case (addressId, txsAll) =>
+        val txs = if (indexAllTransactions) txsAll else txsAll.filter { case (typeId, _) => portfolioTxTypes.contains(typeId.toByte) }
+        val kk                          = Keys.addressTransactionSeqNr(addressId)
+        val nextSeqNr                   = rw.get(kk) + 1
+        val t: Key[Seq[(Int, AssetId)]] = Keys.addressTransactionIds(addressId, nextSeqNr)
+        rw.put(t, txs)
+        rw.put(kk, nextSeqNr)
     }
 
     def f(addr: Address, txs: Seq[AssociationTransaction], seqNrKey: ByteStr => Key[Int], idKey: (ByteStr, Int) => Key[Array[Byte]]) = {

--- a/src/main/scala/com/ltonetwork/history/StorageFactory.scala
+++ b/src/main/scala/com/ltonetwork/history/StorageFactory.scala
@@ -16,7 +16,8 @@ object StorageFactory extends ScorexLogging {
       db,
       settings.blockchainSettings.functionalitySettings,
       settings.maxCacheSize,
-      settings.maxRollbackDepth
+      settings.maxRollbackDepth,
+      settings.indexAllTransactions,
     )
     new BlockchainUpdaterImpl(levelDBWriter, settings, time)
   }

--- a/src/main/scala/com/ltonetwork/settings/LtoSettings.scala
+++ b/src/main/scala/com/ltonetwork/settings/LtoSettings.scala
@@ -9,6 +9,7 @@ case class LtoSettings(directory: String,
                        dataDirectory: String,
                        maxCacheSize: Int,
                        maxRollbackDepth: Int,
+                       indexAllTransactions: Boolean,
                        networkSettings: NetworkSettings,
                        walletSettings: WalletSettings,
                        blockchainSettings: BlockchainSettings,
@@ -30,6 +31,7 @@ object LtoSettings {
     val dataDirectory           = config.as[String]("lto.data-directory")
     val maxCacheSize            = config.as[Int]("lto.max-cache-size")
     val maxRollbackDepth        = config.as[Int]("lto.max-rollback-depth")
+    val indexAllTransactions    = config.as[Boolean]("lto.index-all-transactions")
     val networkSettings         = config.as[NetworkSettings]("lto.network")
     val walletSettings          = config.as[WalletSettings]("lto.wallet")
     val blockchainSettings      = BlockchainSettings.fromConfig(config)
@@ -47,6 +49,7 @@ object LtoSettings {
       dataDirectory,
       maxCacheSize,
       maxRollbackDepth,
+      indexAllTransactions,
       networkSettings,
       walletSettings,
       blockchainSettings,

--- a/src/main/scala/com/ltonetwork/state/BlockchainUpdaterImpl.scala
+++ b/src/main/scala/com/ltonetwork/state/BlockchainUpdaterImpl.scala
@@ -421,15 +421,14 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: LtoSettings, time:
         .collect {
           case (height, tx, addresses) if addresses(address) && (types.isEmpty || types.contains(tx.builder.typeId)) => (height, tx)
         }
-        .slice(from, from + count)
         .toSeq
 
-      val actualTxCount = transactionsFromDiff.length
+      val diffTxCount = transactionsFromDiff.length
 
-      if (actualTxCount == count) transactionsFromDiff
-      else {
-        transactionsFromDiff ++ blockchain.addressTransactions(address, types, count - actualTxCount, 0)
-      }
+      if (diffTxCount >= from + count)
+        transactionsFromDiff.slice(from, from + count)
+      else
+        transactionsFromDiff.slice(from, from + count) ++ blockchain.addressTransactions(address, types, count - diffTxCount, from - diffTxCount)
     }
 
   override def containsTransaction(id: AssetId): Boolean = ngState.fold(blockchain.containsTransaction(id)) { ng =>

--- a/src/main/scala/com/ltonetwork/state/BlockchainUpdaterImpl.scala
+++ b/src/main/scala/com/ltonetwork/state/BlockchainUpdaterImpl.scala
@@ -415,11 +415,13 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: LtoSettings, time:
       .map(t => (t._1, t._2))
       .orElse(blockchain.transactionInfo(id))
 
-  override def addressTransactions(address: Address, types: Set[Byte], count: Int, from: Int): Seq[(Int, Transaction)] =
+  override def addressTransactions(address: Address, types: Set[Byte], count: Int, from: Int): Seq[(Int, Transaction)] = {
+    def onlyTypes: Set[Byte] = if (settings.indexAllTransactions) types else if (types.isEmpty) portfolioTxTypes else types.intersect(portfolioTxTypes)
+
     ngState.fold(blockchain.addressTransactions(address, types, count, from)) { ng =>
       val transactionsFromDiff = ng.bestLiquidDiff.transactions.values.view
         .collect {
-          case (height, tx, addresses) if addresses(address) && (types.isEmpty || types.contains(tx.builder.typeId)) => (height, tx)
+          case (height, tx, addresses) if addresses(address) && (onlyTypes.isEmpty || onlyTypes.contains(tx.builder.typeId)) => (height, tx)
         }
         .toSeq
 
@@ -430,6 +432,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: LtoSettings, time:
       else
         transactionsFromDiff.slice(from, from + count) ++ blockchain.addressTransactions(address, types, count - diffTxCount, from - diffTxCount)
     }
+  }
 
   override def containsTransaction(id: AssetId): Boolean = ngState.fold(blockchain.containsTransaction(id)) { ng =>
     ng.bestLiquidDiff.transactions.contains(id) || blockchain.containsTransaction(id)

--- a/src/main/scala/com/ltonetwork/state/diffs/AnchorTransactionDiff.scala
+++ b/src/main/scala/com/ltonetwork/state/diffs/AnchorTransactionDiff.scala
@@ -1,7 +1,7 @@
 package com.ltonetwork.state.diffs
 
 import com.ltonetwork.features.BlockchainFeatures
-import com.ltonetwork.state.{Blockchain, Diff}
+import com.ltonetwork.state.{Blockchain, Diff, Portfolio}
 import com.ltonetwork.transaction.ValidationError
 import com.ltonetwork.transaction.ValidationError.GenericError
 import com.ltonetwork.transaction.anchor.AnchorTransaction
@@ -25,7 +25,7 @@ object AnchorTransactionDiff {
         Diff(
           height,
           tx,
-          accountData = Map.empty
+          portfolios = Map(tx.sender.toAddress -> Portfolio.empty)
       )
     )
   }

--- a/src/main/scala/com/ltonetwork/state/diffs/AssociationTransactionDiff.scala
+++ b/src/main/scala/com/ltonetwork/state/diffs/AssociationTransactionDiff.scala
@@ -1,6 +1,6 @@
 package com.ltonetwork.state.diffs
 
-import com.ltonetwork.state.Diff
+import com.ltonetwork.state.{Diff, Portfolio}
 import com.ltonetwork.transaction.ValidationError
 import com.ltonetwork.transaction.association.AssociationTransaction
 
@@ -11,6 +11,6 @@ object AssociationTransactionDiff {
       Diff(
         height,
         tx,
-        accountData = Map.empty,
+        portfolios = Map(tx.sender.toAddress -> Portfolio.empty)
       ))
 }

--- a/src/main/scala/com/ltonetwork/state/diffs/DataTransactionDiff.scala
+++ b/src/main/scala/com/ltonetwork/state/diffs/DataTransactionDiff.scala
@@ -2,7 +2,7 @@ package com.ltonetwork.state.diffs
 
 import com.ltonetwork.features.BlockchainFeatures
 import com.ltonetwork.features.FeatureProvider._
-import com.ltonetwork.state.{AccountDataInfo, Blockchain, Diff}
+import com.ltonetwork.state.{AccountDataInfo, Blockchain, Diff, Portfolio}
 import com.ltonetwork.transaction.ValidationError
 import com.ltonetwork.transaction.ValidationError.GenericError
 import com.ltonetwork.transaction.data.DataTransaction
@@ -30,6 +30,7 @@ object DataTransactionDiff {
         Diff(
           height,
           tx,
+          portfolios = Map(tx.sender.toAddress -> Portfolio.empty),
           accountData = Map(tx.sender.toAddress -> AccountDataInfo(tx.data.map(item => item.key -> item).toMap))
         )
     )

--- a/src/main/scala/com/ltonetwork/state/diffs/RegisterTransactionDiff.scala
+++ b/src/main/scala/com/ltonetwork/state/diffs/RegisterTransactionDiff.scala
@@ -1,10 +1,14 @@
 package com.ltonetwork.state.diffs
 
-import com.ltonetwork.state.{Blockchain, Diff}
+import com.ltonetwork.state.{Blockchain, Diff, Portfolio}
 import com.ltonetwork.transaction.ValidationError
 import com.ltonetwork.transaction.register.RegisterTransaction
 
 object RegisterTransactionDiff {
   def apply(blockchain: Blockchain, height: Int)(tx: RegisterTransaction): Either[ValidationError, Diff] =
-    Right(Diff(height, tx))
+    Right(Diff(
+      height,
+      tx,
+      Map(tx.sender.toAddress -> Portfolio.empty)
+    ))
 }

--- a/src/main/scala/com/ltonetwork/state/diffs/SetScriptTransactionDiff.scala
+++ b/src/main/scala/com/ltonetwork/state/diffs/SetScriptTransactionDiff.scala
@@ -1,10 +1,8 @@
 package com.ltonetwork.state.diffs
 
-import com.ltonetwork.state.Diff
+import com.ltonetwork.state.{Diff, Portfolio}
 import com.ltonetwork.transaction.ValidationError
 import com.ltonetwork.transaction.smart.SetScriptTransaction
-
-import scala.util.Right
 
 object SetScriptTransactionDiff {
   def apply(height: Int)(tx: SetScriptTransaction): Either[ValidationError, Diff] = {
@@ -12,6 +10,7 @@ object SetScriptTransactionDiff {
       Diff(
         height = height,
         tx = tx,
+        portfolios = Map(tx.sender.toAddress -> Portfolio.empty),
         scripts = Map(tx.sender.toAddress -> tx.script)
       ))
   }

--- a/src/main/scala/com/ltonetwork/transaction/package.scala
+++ b/src/main/scala/com/ltonetwork/transaction/package.scala
@@ -3,6 +3,11 @@ package com.ltonetwork
 import cats.data.ValidatedNel
 import com.ltonetwork.account.{PrivateKeyAccount, PublicKeyAccount}
 import com.ltonetwork.block.{Block, MicroBlock}
+import com.ltonetwork.transaction.burn.BurnTransaction
+import com.ltonetwork.transaction.genesis.GenesisTransaction
+import com.ltonetwork.transaction.lease.{CancelLeaseTransaction, LeaseTransaction}
+import com.ltonetwork.transaction.sponsorship.{CancelSponsorshipTransaction, SponsorshipTransaction}
+import com.ltonetwork.transaction.transfer.{MassTransferTransaction, TransferTransaction}
 
 package object transaction {
   type AssetId = com.ltonetwork.state.ByteStr
@@ -10,6 +15,18 @@ package object transaction {
   type DiscardedTransactions = Seq[Transaction]
   type DiscardedBlocks       = Seq[Block]
   type DiscardedMicroBlocks  = Seq[MicroBlock]
+
+
+  def portfolioTxTypes: Set[Byte] = Set(
+    GenesisTransaction.typeId,
+    TransferTransaction.typeId,
+    MassTransferTransaction.typeId,
+    BurnTransaction.typeId,
+    LeaseTransaction.typeId,
+    CancelLeaseTransaction.typeId,
+    SponsorshipTransaction.typeId,
+    CancelSponsorshipTransaction.typeId,
+  )
 
   implicit class TransactionValidationOps[T <: Transaction](val tx: T) extends AnyVal {
     def validatedNel(implicit validator: TxValidator[T]): ValidatedNel[ValidationError, T] = validator.validate(tx)

--- a/src/test/scala/com/ltonetwork/http/TransactionsRouteSpec.scala
+++ b/src/test/scala/com/ltonetwork/http/TransactionsRouteSpec.scala
@@ -110,18 +110,18 @@ class TransactionsRouteSpec
 
   }
 
-  routePath("/address/{address}/limit/{limit}") - {
+  routePath("/address/{address}") - {
     "handles invalid address" in {
       forAll(bytes32gen, choose(1, MaxTransactionsPerRequest)) {
         case (bytes, limit) =>
-          Get(routePath(s"/address/${Base58.encode(bytes)}/limit/$limit")) ~> route should produce(InvalidAddress)
+          Get(routePath(s"/address/${Base58.encode(bytes)}?limit=$limit")) ~> route should produce(InvalidAddress)
       }
     }
 
     "handles invalid limit" in {
-      forAll(accountGen, alphaStr.label("alphaNumericLimit")) {
-        case (account, invalidLimit) =>
-          Get(routePath(s"/address/${account.address}/limit/$invalidLimit")) ~> route ~> check {
+      forAll(accountGen) {
+        account =>
+          Get(routePath(s"/address/${account.address}?limit=-1")) ~> route ~> check {
             status shouldEqual StatusCodes.BadRequest
             (responseAs[JsObject] \ "message").as[String] shouldEqual "invalid.limit"
           }
@@ -129,7 +129,7 @@ class TransactionsRouteSpec
 
       forAll(accountGen, choose(MaxTransactionsPerRequest + 1, Int.MaxValue).label("limitExceeded")) {
         case (account, limit) =>
-          Get(routePath(s"/address/${account.address}/limit/$limit")) ~> route should produce(TooBigArrayAllocation)
+          Get(routePath(s"/address/${account.address}?limit=$limit")) ~> route should produce(TooBigArrayAllocation)
       }
     }
 


### PR DESCRIPTION
Added the option to index all transactions instead of only txs that change the portfolio. See #55
Use query parameters for limit and offset.