### PR TITLE
DNS names instead of IP addresses for known peers

### DIFF
--- a/lto-mainnet.conf
+++ b/lto-mainnet.conf
@@ -4,12 +4,12 @@ lto {
   # P2P Network settings
   network {
     known-peers = [
-      "63.34.51.159:6868",
-      "52.45.54.23:6868",
-      "13.114.144.48:6868",
-      "116.203.3.144:6868",
-      "116.203.166.56:6868",
-      "116.203.167.249:6868"
+      "bs1.lto.network:6868",
+      "bs2.lto.network:6868",
+      "bs3.lto.network:6868",
+      "node.ltoblockchainnode.com:6868",
+      "node.ltonod.es:6868",
+      "zolnode.basta.pro:6868",
     ]
 
     # Network address

--- a/lto-testnet.conf
+++ b/lto-testnet.conf
@@ -4,8 +4,9 @@ lto {
   # P2P Network settings
   network {
     known-peers = [
-      "116.203.167.231:6863",
-      "116.203.167.188:6863"
+      "bs1.testnet.lto.network:6863",
+      "bs2.testnet.lto.network:6863",
+      "bs3.testnet.lto.network:6863",
     ]
 
     # Network address


### PR DESCRIPTION
Configure DNS names instead of IP addresses for known-peers in mainnet and testnet configurations.

For mainnet set 3 bootstrap nodes and 3 community nodes as known peers.
* [ltonod.es](https://ltonod.es)
* [LTO Blockchain Node](https://ltoblockchainnode.com/)
* Zolnode

![thankyou](https://user-images.githubusercontent.com/100821/201368893-55ff75f5-4ea8-48da-b8ff-9ae9243c4279.gif)
